### PR TITLE
Enhance Rx API for SignalR client and update dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,100 +1,161 @@
-# CP.AspNetCore.SignalR.Client.Rx
+﻿# CP.AspNetCore.SignalR.Client.Rx
 Reactive Extensions for Microsoft.AspNetCore.SignalR.Client
 
 ## Installation
 
-```
+```powershell
 Install-Package CP.AspNetCore.SignalR.Client.Rx
 ```
 
-## Usage
+## Overview
+
+CP.AspNetCore.SignalR.Client.Rx provides a set of high-performance, memory-efficient Reactive Extensions (Rx) for SignalR client applications. It enables idiomatic, composable, and observable-based programming for SignalR events, streaming, and connection management.
+
+- **Targets:** .NET Standard 2.0, .NET Framework 4.6.2, .NET 8, .NET 9
+- **Supports:** WPF, WinForms, Console, ASP.NET Core, Razor Pages, and more
+
+## Quick Start
 
 ```csharp
 using CP.AspNetCore.SignalR.Client.Rx;
-```
+using Microsoft.AspNetCore.SignalR.Client;
 
-```csharp
 var connection = new HubConnectionBuilder()
     .WithUrl("http://localhost:5000/hub")
-    .AutoReconnect()
+    .WithAutomaticReconnect()
     .Build();
 
+// Subscribe to a hub method
 var sub = connection.On<string>("Stream").Subscribe(Console.WriteLine);
 
-var con = connection.StartAsync().Subscribe();
+// Start the connection reactively
+connection.StartObservable().Subscribe();
 ```
 
-## Other options
-    
+## Advanced Usage
+
+### Using HubBuilder for Lifecycle Management
+
 ```csharp
-    HubBuilder.Create(builder => builder.WithUrl("https://localhost:53933/ChatHub"))
+using CP.AspNetCore.SignalR.Client.Rx;
+using System.Reactive.Disposables;
+
+HubBuilder.Create(builder => builder.WithUrl("https://localhost:53933/ChatHub"))
     .Subscribe(x =>
     {
         var connection = x.hubConnection;
-        x.disposables.Add(connection.On<string, string>("ReceiveMessage").Subscribe(responce => Dispatcher.Invoke(() =>
-        {
-            var newMessage = $"{responce.t1}: {responce.t2}";
-            messagesList.Items.Add(newMessage);
-        })));
+        var disposables = x.disposables;
 
-        x.disposables.Add(connection.HasClosed().Subscribe(error => Dispatcher.Invoke(() =>
-        {
-            connectButton.IsEnabled = true;
-            sendButton.IsEnabled = false;
-            messagesList.Items.Add(error);
-        })));
+        // Listen for messages
+        disposables.Add(connection.On<string, string>("ReceiveMessage")
+            .Subscribe(msg => Console.WriteLine($"{msg.t1}: {msg.t2}")));
 
-        x.disposables.Add(connectButton.Events().Click.Start(connection).Subscribe(_ => Dispatcher.Invoke(() =>
-        {
-            try
-            {
-                messagesList.Items.Add("Connection started");
-                connectButton.IsEnabled = false;
-                sendButton.IsEnabled = true;
-            }
-            catch (Exception ex)
-            {
-                messagesList.Items.Add(ex.Message);
-            }
-        })));
+        // Handle connection closed
+        disposables.Add(connection.HasClosed().Subscribe(error =>
+            Console.WriteLine($"Closed: {error?.Message}")));
 
-        x.disposables.Add(sendButton.Events().Click.Subscribe(_ => Dispatcher.Invoke(async () =>
-        {
-            try
-            {
-                await connection.InvokeAsync("SendMessage", userTextBox.Text, messageTextBox.Text);
-            }
-            catch (Exception ex)
-            {
-                messagesList.Items.Add(ex.Message);
-            }
-        })));
+        // Start connection on some trigger (e.g., button click)
+        // disposables.Add(button.Events().Click.Start(connection).Subscribe());
     });
 ```
 
-## Available operators
+### Streaming from the Server
 
+```csharp
+connection.StreamObservable<int>("Counter", CancellationToken.None, 10)
+    .Subscribe(
+        value => Console.WriteLine($"Received: {value}"),
+        ex => Console.WriteLine($"Error: {ex.Message}"),
+        () => Console.WriteLine("Stream completed"));
+```
+
+### Invoking Methods and Sending Data
+
+```csharp
+// Invoke a method and get a result
+connection.InvokeObservable<int>("AddNumbers", CancellationToken.None, 1, 2)
+    .Subscribe(result => Console.WriteLine($"Sum: {result}"));
+
+// Send a method (fire-and-forget)
+connection.SendObservable("Notify", CancellationToken.None, "Hello!")
+    .Subscribe(_ => Console.WriteLine("Notification sent"));
+```
+
+### Observing Connection State
+
+```csharp
+connection.StateChanges().Subscribe(state =>
+    Console.WriteLine($"Connection state: {state}"));
+
+// Wait for a specific state
+connection.WaitForState(HubConnectionState.Connected)
+    .Subscribe(_ => Console.WriteLine("Connected!"));
+```
+
+### Razor Pages Example
+
+```csharp
+@page
+@using CP.AspNetCore.SignalR.Client.Rx
+@inject Microsoft.AspNetCore.SignalR.Client.HubConnection Connection
+
+@functions {
+    protected override void OnInitialized()
+    {
+        Connection.On<string>("ReceiveMessage")
+            .Subscribe(msg => /* update UI */);
+        Connection.StartObservable().Subscribe();
+    }
+}
+```
+
+## API Reference
+
+### Event Subscription
+- `On(string methodName)` — No-arg handler
 - `On<T>(string methodName)`
 - `On<T1, T2>(string methodName)`
-- `On<T1, T2, T3>(string methodName)`
-- `On<T1, T2, T3, T4>(string methodName)`
-- `On<T1, T2, T3, T4, T5>(string methodName)`
-- `On<T1, T2, T3, T4, T5, T6>(string methodName)`
-- `On<T1, T2, T3, T4, T5, T6, T7>(string methodName)`
-- `On<T1, T2, T3, T4, T5, T6, T7, T8>(string methodName)`
+- ... up to 8 arguments
 
+### Connection Lifecycle
+- `StartObservable([CancellationToken])`
+- `StartObservable(int? retryCount, [CancellationToken])`
+- `StopObservable([CancellationToken])`
+- `StopObservable(int? retryCount, [CancellationToken])`
+- `EnsureStarted([CancellationToken])`
+- `StateChanges()`
+- `WaitForState(HubConnectionState)`
+
+### Streaming
+- `StreamObservable<T>(string methodName, [CancellationToken], params object?[] args)`
+
+### Invocation
+- `InvokeObservable<T>(string methodName, [CancellationToken], params object?[] args)`
+- `InvokeObservable(string methodName, [CancellationToken], params object?[] args)`
+- `SendObservable(string methodName, [CancellationToken], params object?[] args)`
+
+### Connection Events
 - `HasClosed()`
-- `HasReconnected()`
 - `IsReconnecting()`
-- `StartObservable()`
-- `StartObservable(CancellationToken cancellationToken)`
-- `Start()`
-- `Start(CancellationToken cancellationToken)`
-- `Start(HubConnection connection)`
-- `Start(HubConnection connection, CancellationToken cancellationToken)`
-- `StopObservable()`
-- `StreamObservable()`
+- `HasReconnected()`
 
-- `InvokeAsync(string methodName, params object[] args)`
+### HubBuilder
+- `HubBuilder.Create(Func<HubConnectionBuilder, IHubConnectionBuilder>)`
 
-- `HubBuilder.Create(builder => // Configure Builder)`
+## Best Practices
+- Always dispose subscriptions to avoid memory leaks.
+- Use `CompositeDisposable` for managing multiple subscriptions.
+- Prefer `StartObservable`/`StopObservable` for connection management in Rx scenarios.
+- Use `StreamObservable` for server-to-client streaming.
+
+## License
+MIT
+
+## See Also
+- [Microsoft.AspNetCore.SignalR.Client Documentation](https://learn.microsoft.com/aspnet/core/signalr/dotnet-client)
+- [Reactive Extensions (Rx)](https://github.com/dotnet/reactive)
+
+---
+
+
+**CP.AspNetCore.SignalR.Client.Rx** - Empowering Industrial Automation with Reactive Technology ⚡🏭

--- a/src/CP.AspNetCore.SignalR.Client.Rx/CP.AspNetCore.SignalR.Client.Rx.csproj
+++ b/src/CP.AspNetCore.SignalR.Client.Rx/CP.AspNetCore.SignalR.Client.Rx.csproj
@@ -7,11 +7,11 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="9.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="9.0.9" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Reactive" Version="6.0.1" />
+    <PackageReference Include="System.Reactive" Version="6.0.2" />
   </ItemGroup>
 
 </Project>

--- a/src/CP.AspNetCore.SignalR.Client.Rx/OnMixins.cs
+++ b/src/CP.AspNetCore.SignalR.Client.Rx/OnMixins.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Chris Pulman. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Reactive;
 using System.Reactive.Linq;
 using Microsoft.AspNetCore.SignalR.Client;
 
@@ -11,6 +12,19 @@ namespace CP.AspNetCore.SignalR.Client.Rx;
 /// </summary>
 public static class OnMixins
 {
+    /// <summary>
+    /// Registers a handler that will be invoked when the hub method with the specified method name is invoked.
+    /// </summary>
+    /// <param name="connection">The connection.</param>
+    /// <param name="methodName">Name of the method.</param>
+    /// <returns>An Observable of Unit.</returns>
+    public static IObservable<Unit> On(this HubConnection connection, string methodName) =>
+        Observable.Create<Unit>(observer =>
+        {
+            var handler = new Action(() => observer.OnNext(Unit.Default));
+            return connection.On(methodName, handler);
+        });
+
     /// <summary>
     /// Registers a handler that will be invoked when the hub method with the specified method name is invoked.
     /// </summary>

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-    "version": "1.2",
+    "version": "1.3",
     "publicReleaseRefSpec": [
         "^refs/heads/main$",
         "^refs/heads/master$",


### PR DESCRIPTION
Expanded the Reactive Extensions API for SignalR client with new methods for connection lifecycle (Start/Stop with retry, EnsureStarted), streaming, invocation, and state observation. Improved documentation in README with advanced usage and API reference. Added support for On with no arguments. Updated dependencies: Microsoft.AspNetCore.SignalR.Client to 9.0.9 and System.Reactive to 6.0.2. Bumped version to 1.3.