### PR TITLE
Add .NET 8.0 and 10.0 support to project

### DIFF
--- a/src/CP.AspNetCore.SignalR.Client.Rx/CP.AspNetCore.SignalR.Client.Rx.csproj
+++ b/src/CP.AspNetCore.SignalR.Client.Rx/CP.AspNetCore.SignalR.Client.Rx.csproj
@@ -1,13 +1,21 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net462;net9.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net462;net8.0;net9.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
+
+  <ItemGroup Condition="$(TargetFramework.StartsWith('net10')) or $(TargetFramework.StartsWith('netstandard2')) or $(TargetFramework.StartsWith('net4'))">
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.0-rc.1.25451.107" />
+  </ItemGroup>
   
-  <ItemGroup>
+  <ItemGroup Condition="$(TargetFramework.StartsWith('net9'))">
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="9.0.9" />
+  </ItemGroup>
+
+  <ItemGroup Condition="$(TargetFramework.StartsWith('net8'))">
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.20" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Updated the project to target net8.0 and net10.0 frameworks. Added conditional package references for Microsoft.AspNetCore.SignalR.Client to match each framework version.